### PR TITLE
Fixed reference to ppTenantId

### DIFF
--- a/DeployPowerPlatform/action.yaml
+++ b/DeployPowerPlatform/action.yaml
@@ -54,7 +54,7 @@ runs:
       uses: microsoft/powerplatform-actions/who-am-i@v0
       with:
         environment-url: ${{env.ppEnvironmentUrl}}
-        tenant-id: ${{env.tenantId}}
+        tenant-id: ${{env.ppTenantId}}
         app-id: ${{env.ppApplicationId}}
         client-secret: ${{env.ppClientSecret}}
  

--- a/DeployPowerPlatform/action.yaml
+++ b/DeployPowerPlatform/action.yaml
@@ -110,7 +110,7 @@ runs:
       uses: microsoft/powerplatform-actions/import-solution@v0
       with:
         environment-url: ${{env.ppEnvironmentUrl}}
-        tenant-id: ${{env.tenantId}}
+        tenant-id: ${{env.ppTenantId}}
         app-id: ${{env.ppApplicationId}}
         client-secret: ${{env.ppClientSecret}}
         solution-file: .artifacts/tempPPSolution/ppsolution.zip


### PR DESCRIPTION
ReadDeploymentAndAuthSetttings.ps1 saves the Tenant ID from the AUTHCONTEXT in a vairable named ppTenantId however DeployPowerPlatform does not reference this correctly when using client secret authentication.