### PR TITLE
V5-hotfix1

### DIFF
--- a/AL-Go-Helper.ps1
+++ b/AL-Go-Helper.ps1
@@ -1803,6 +1803,7 @@ function CreateDevEnv {
                     "artifact"   = $settings.artifact.replace('{INSIDERSASTOKEN}', '')
                     "auth"       = $auth
                     "credential" = $credential
+                    "keepContainer" = $true
                 }
                 if ($containerName) {
                     $runAlPipelineParams += @{
@@ -1921,8 +1922,7 @@ function CreateDevEnv {
                 -obsoleteTagMinAllowedMajorMinor $settings.obsoleteTagMinAllowedMajorMinor `
                 -doNotRunTests `
                 -doNotRunBcptTests `
-                -useDevEndpoint `
-                -keepContainer
+                -useDevEndpoint
         }
         finally {
             Pop-Location
@@ -2190,7 +2190,7 @@ function DetermineArtifactUrl {
 
     if ($artifact -like "https://*") {
         $artifactUrl = $artifact
-        $storageAccount = ("$artifactUrl////".Split('/')[2]).Split('.')[0]
+        $storageAccount = ("$artifactUrl////".Split('/')[2])
         $artifactType = ("$artifactUrl////".Split('/')[3])
         $version = ("$artifactUrl////".Split('/')[4])
         $country = ("$artifactUrl////".Split('?')[0].Split('/')[5])

--- a/BuildReferenceDocumentation/BuildReferenceDocumentation.HelperFunctions.ps1
+++ b/BuildReferenceDocumentation/BuildReferenceDocumentation.HelperFunctions.ps1
@@ -1,7 +1,7 @@
 function DownloadAlDoc {
     if ("$ENV:aldocPath" -eq "") {
         Write-Host "Locating aldoc"
-        $artifactUrl = Get-BCArtifactUrl -storageAccount bcinsider -type sandbox -country core -select Latest -accept_insiderEula
+        $artifactUrl = Get-BCArtifactUrl -type sandbox -country core -select Latest -accept_insiderEula
         Write-Host "Downloading aldoc"
         $folder = Download-Artifacts $artifactUrl
         $alLanguageVsix = Join-Path $folder '*.vsix' -Resolve
@@ -24,7 +24,7 @@ function DownloadAlDoc {
             & /usr/bin/env sudo pwsh -command "& chmod +x $ENV:aldocPath"
         }
         Write-Host "Installing/Updating docfx"
-        CmdDo -command dotnet -arguments @("tool","update","-g docfx") -messageIfCmdNotFound "dotnet not found. Please install it from https://dotnet.microsoft.com/download"
+        CmdDo -command dotnet -arguments @("tool","update","--global docfx --version 2.75.3") -messageIfCmdNotFound "dotnet not found. Please install it from https://dotnet.microsoft.com/download"
     }
     return $ENV:aldocPath
 }

--- a/BuildReferenceDocumentation/BuildReferenceDocumentation.ps1
+++ b/BuildReferenceDocumentation/BuildReferenceDocumentation.ps1
@@ -47,7 +47,9 @@ if ($maxReleases -gt 0) {
 }
 
 $docsPath = Join-Path $ENV:GITHUB_WORKSPACE ".aldoc"
-New-Item $docsPath -ItemType Directory | Out-Null
+if (!(Test-Path -path $docsPath)) {
+    New-Item $docsPath -ItemType Directory | Out-Null
+}
 $loglevel = 'Info'
 
 $versions = @($releases | ForEach-Object { $_.Name })


### PR DESCRIPTION
Hotfix these issues:
Issue 1021 Error during Create Online Development Environment action
Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
Issue 922 Deploy Reference Documentation (ALDoc) failed with custom

Also Deploy reference documentation stopped working with docfx 2.76.0 - this hotfix forces 2.75.3 (which works)