### PR TITLE
Update PR Create command to not use Invoke-Expression

### DIFF
--- a/AL-Go-Helper.ps1
+++ b/AL-Go-Helper.ps1
@@ -1409,14 +1409,13 @@ function CommitFromNewFolder {
         }
         invoke-git push -u $serverUrl $branch
         try {
-            $prCreateCmd = "invoke-gh pr create --fill --title ""$title"" --head ""$branch"" --repo ""$env:GITHUB_REPOSITORY"" --base ""$ENV:GITHUB_REF_NAME"" --body ""$body"""
             if ($settings.commitOptions.pullRequestLabels) {
                 $labels = "$($settings.commitOptions.pullRequestLabels -join ",")"
                 Write-Host "Adding labels: $labels"
-                $prCreateCmd += " --label ""$labels"""
+                invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --base $ENV:GITHUB_REF_NAME --body "$body" --label $labels
+            } else {
+                invoke-gh pr create --fill --head $branch --repo $env:GITHUB_REPOSITORY --base $ENV:GITHUB_REF_NAME --body "$body"
             }
-
-            Invoke-Expression $prCreateCmd
 
             if ($settings.commitOptions.pullRequestAutoMerge) {
                 invoke-gh pr merge --auto --squash --delete-branch


### PR DESCRIPTION
Current Update AL-Go System files is failing on BCApps: 
https://github.com/microsoft/BCApps/actions/runs/12389564864

When invoking gh-cli it throws the error: 
`unknown arguments ["appFolders optional\n- Issue 1344 Experimental feature git" "submodules seems to be a breaking change\n- Issue 1305 Extra telemetry Property RepositoryOwner and RepositoryName¨\n- Add RunnerEnvironment to Telemetry\n- Output a notice, not a warning, when there are no available updates for AL-Go for GitHub\n\n### New Repository Settings\n\n- useGitSubmodules can be either \true or \recursive if you want to enable Git Submodules in your repository. If your Git submodules reside`

Error most likely stems from unescaped characters in the release notes. 

Update PR Create command to not use Invoke-Expression