### PR TITLE
Fix error on git rev-list

### DIFF
--- a/CheckForUpdates/CheckForUpdates.ps1
+++ b/CheckForUpdates/CheckForUpdates.ps1
@@ -212,7 +212,7 @@ else {
     # $update set, update the files
     try {
         # If a pull request already exists with the same REF, then exit
-        $branchSHA = RunAndCheck git rev-list -n 1 $updateBranch
+        $branchSHA = RunAndCheck git rev-list -n 1 $updateBranch '--'
         $commitMessage = "[$($updateBranch)@$($branchSHA.SubString(0,7))] Update AL-Go System Files from $templateInfo - $($templateSha.SubString(0,7))"
 
         # Get Token with permissions to modify workflows in this repository


### PR DESCRIPTION
Error: fatal: ambiguous argument 'main': both revision and filename means that there is both a branch named main and a file or a directory, named main.

Related to microsoft/AL-Go#1526