### PR TITLE
Fix type of projects setting in schema

### DIFF
--- a/settings.schema.json
+++ b/settings.schema.json
@@ -19,7 +19,7 @@
         "projects": {
             "type": "array",
             "items": {
-                "type": "object"
+                "type": "string"
             },
             "description": "An array of AL-Go projects. See https://aka.ms/ALGoSettings#projects"
         },


### PR DESCRIPTION
Schema for projects setting should be an array of strings.

Related to https://github.com/microsoft/AL-Go/issues/1770