### PR TITLE
Using basic parsing in CheckForUpdates WebCall

### DIFF
--- a/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
+++ b/CheckForUpdates/CheckForUpdates.HelperFunctions.ps1
@@ -25,7 +25,7 @@ function DownloadTemplateRepository {
     OutputDebug -message "Getting template repository ($templateRepository) with GITHUB_TOKEN"
     $headers = GetHeaders -token $env:GITHUB_TOKEN -repository $templateRepository
     try {
-        $response = Invoke-WebRequest -Headers $headers -Method Head -Uri $templateRepositoryUrl
+        $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Method Head -Uri $templateRepositoryUrl
         OutputDebug -message ($response | Format-List | Out-String)
     }
     catch {


### PR DESCRIPTION
On some self-hosted runners, Internet Explorer engine might not be available. This appears to fail Invoke-WebRequest calls if -UseBasicParsing is not used.