### PR TITLE
[v9.0] Pass vsixFile setting to New-BcCompilerFolder in workspace compilation

### DIFF
--- a/CompileApps/Compile.ps1
+++ b/CompileApps/Compile.ps1
@@ -100,7 +100,7 @@ try {
         # On GitHub-hosted runners, use a folder in the runner temp directory for caching to speed up subsequent builds
         $cacheFolder = Join-Path $ENV:RUNNER_TEMP ".artifactcache"
     }
-    $compilerFolder = New-BcCompilerFolder -artifactUrl $artifact -containerName "$($containerName)compiler" -cacheFolder $cacheFolder
+    $compilerFolder = New-BcCompilerFolder -artifactUrl $artifact -vsixFile $settings.vsixFile -containerName "$($containerName)compiler" -cacheFolder $cacheFolder
     $packageCachePath = Join-Path $compilerFolder "symbols"
 
     # Copy dependency apps to the package cache so the compiler can resolve them


### PR DESCRIPTION
Workspace compilation was ignoring the vsixFile setting because it was not passed to New-BcCompilerFolder. The traditional compilation path already honors this setting. When vsixFile is empty (the default), BcContainerHelper ignores the parameter and falls back to the artifact-bundled compiler, so existing behavior is preserved.

Fixes microsoft/AL-Go#2204